### PR TITLE
SRVKS-29: Update docs to point to our 0.3.0 release

### DIFF
--- a/knative-OCP-4x.md
+++ b/knative-OCP-4x.md
@@ -26,7 +26,7 @@
    `git clone https://github.com/openshift-cloud-functions/knative-operators`   
    `cd knative-operators/`   
    `git fetch --tags`   
-   `git checkout openshift-v0.2.0`   
+   `git checkout openshift-v0.3.0`   
 
 3. Set the following SSH properties using your OpenShift cluster credentials.
 

--- a/proc_installing-knative-OCP-4x.adoc
+++ b/proc_installing-knative-OCP-4x.adoc
@@ -24,7 +24,7 @@ NOTE: This Knative on OpenShift preview is only available by using the OpenShift
    `git clone https://github.com/openshift-cloud-functions/knative-operators`   
    `cd knative-operators/`   
    `git fetch --tags`   
-   `git checkout openshift-v0.2.0`   
+   `git checkout openshift-v0.3.0`   
 
 . Set the following SSH properties using your OpenShift cluster credentials.
 


### PR DESCRIPTION
https://github.com/openshift-cloud-functions/Documentation/blob/23ef3a3db5a6c59045a87d8aced0595e1bd58a06/knative-OCP-4x.md still points to `v0.2.0` but should point to `v0.3.0` tag of our knative-operators repo.

* That tag does not exist yet, but that's what the tag will be.

**Jira ref:** (https://jira.coreos.com/browse/SRVKS-27)