### PR TITLE
SRVKS-27: SSH keys not required for Knative installation on OCP4

### DIFF
--- a/assembly_knative-OCP-311.adoc
+++ b/assembly_knative-OCP-311.adoc
@@ -13,4 +13,4 @@ include::con_knative-OCP-311.adoc[leveloffset=+1]
 include::proc_installing-knative-OCP-311.adoc[leveloffset=+1] 
 
 // Allowing external access to Knative services using a configured hostname (post-installation tasks)
-include::proc_allowing-external-access-knative-services-OCP-311.adoc
+include::proc_allowing-external-access-knative-services-OCP-311.adoc[leveloffset=+1] 

--- a/assembly_knative-OCP-4x.adoc
+++ b/assembly_knative-OCP-4x.adoc
@@ -10,4 +10,4 @@
 include::con_knative-OCP-4x.adoc[leveloffset=+1]
 
 // Installing Knative on an OpenShift cluster 4.0 using the script provided
-include::proc_install-knative-OCP-4x.adoc[leveloffset=+1] 
+include::proc_installing-knative-OCP-4x.adoc[leveloffset=+1] 

--- a/assembly_knative-minishift.adoc
+++ b/assembly_knative-minishift.adoc
@@ -10,4 +10,4 @@
 include::con_knative-minishift.adoc[leveloffset=+1]
 
 // Installing Knative on a Minishift cluster using `install-on-minishift.sh`
-include::proc_install-knative-minishift.adoc[leveloffset=+1] 
+include::proc_installing-knative-minishift.adoc[leveloffset=+1] 

--- a/con_knative-OCP-4x.adoc
+++ b/con_knative-OCP-4x.adoc
@@ -2,6 +2,7 @@
 //
 // assembly_knative-OCP-4x.adoc
 
+
 [id='knative-ocp-4x_{context}']
 = Knative on an OpenShift 4.0 cluster
 

--- a/knative-OCP-4x.md
+++ b/knative-OCP-4x.md
@@ -26,7 +26,7 @@
    `git clone https://github.com/openshift-cloud-functions/knative-operators`   
    `cd knative-operators/`   
    `git fetch --tags`   
-   `git checkout openshift-v0.2.0`   
+   `git checkout openshift-v0.3.0`   
 
 3. Set the following SSH properties using your OpenShift cluster credentials.
 

--- a/knative-OCP-4x.md
+++ b/knative-OCP-4x.md
@@ -36,7 +36,7 @@
 
 4.  Once the script starts, you will see the following warning and prompt:
 
-    `This script will attempt to install Istio, Knative, and OLM in your Kubernetes/OpenShift cluster.`
+    `WARNING: This script will attempt to install Istio, Knative, and OLM in your Kubernetes/OpenShift cluster.`
     
     `If targeting OpenShift, a recent version of 'oc' should be available in your PATH. Otherwise, 'kubectl' will be used.`
 

--- a/knative-OCP-4x.md
+++ b/knative-OCP-4x.md
@@ -34,14 +34,16 @@
 
 >**NOTE** The installation script takes around 20-30 minutes to complete, depending on your system.
 
-4. Once the script starts, you will see the following warning and prompt.
+4.  Once the script starts, you will see the following warning and prompt:
 
-   `WARNING: This script will blindly attempt to install OLM, istio, and knative on your OpenShift cluster, so if   any are already there, hijinks may ensue.`
+    `This script will attempt to install Istio, Knative, and OLM in your Kubernetes/OpenShift cluster.`
+    
+    `If targeting OpenShift, a recent version of 'oc' should be available in your PATH. Otherwise, 'kubectl' will be used.`
 
-   `If your cluster isn't minishift, ensure $KUBE_SSH_KEY and $KUBE_SSH_USER are set`   
+    `If using OpenShift 3.11 and your cluster isn't minishift, ensure \$KUBE_SSH_KEY and \$KUBE_SSH_USER are set`
 
-   `Pass -q to disable this warning`   
+    `Pass -q to disable this prompt`
+ 
+    `Enter to continue or Ctrl-C to exit:`
 
-   `Enter to continue or Ctrl-C to exit:`   
-
-5. Press Enter to continue.
+. Press Enter to continue.

--- a/knative-OCP-4x.md
+++ b/knative-OCP-4x.md
@@ -28,18 +28,13 @@
    `git fetch --tags`   
    `git checkout openshift-v0.3.0`   
 
-3. Set the following SSH properties using your OpenShift cluster credentials.
-
-   `export KUBE_SSH_USER=<username>`   
-   `export KUBE_SSH_KEY=<path-to-private-ssh-key>`   
-
-4. Navigate to the newly cloned repository and run the `install.sh` script.
+3. Navigate to the newly cloned repository and run the `install.sh` script.
 
    `./etc/scripts/install.sh`  
 
 >**NOTE** The installation script takes around 20-30 minutes to complete, depending on your system.
 
-5. Once the script starts, you will see the following warning and prompt.
+4. Once the script starts, you will see the following warning and prompt.
 
    `WARNING: This script will blindly attempt to install OLM, istio, and knative on your OpenShift cluster, so if   any are already there, hijinks may ensue.`
 
@@ -49,4 +44,4 @@
 
    `Enter to continue or Ctrl-C to exit:`   
 
-   Press Enter to continue.
+5. Press Enter to continue.

--- a/master.adoc
+++ b/master.adoc
@@ -1,4 +1,6 @@
-
+//
+//
+//
 
 
 = Knative on OpenShift documentation

--- a/proc_allowing-external-access-knative-services-OCP-311.adoc
+++ b/proc_allowing-external-access-knative-services-OCP-311.adoc
@@ -4,7 +4,7 @@
 
 
 [id='allowing-external-access-knative-services_{context}]
-=Allowing external access to Knative services
+= Allowing external access to Knative services
 
 Use a configured hostname to access Knative services.
 

--- a/proc_allowing-external-access-knative-services-OCP-311.adoc
+++ b/proc_allowing-external-access-knative-services-OCP-311.adoc
@@ -62,3 +62,9 @@ NOTE: This route requires one host per namespace, which runs Knative services. T
 . View the domain that was assigned to the application. You can now access the demo application using this domain.
 
    `oc get service.serving.knative.dev/dumpy`   
+
+
+
+.Additional resources
+
+* For more information about default routing subdomains, see link:https://docs.openshift.com/enterprise/3.0/install_config/install/deploy_router.html#customizing-the-default-routing-subdomain[OpenShift documentation].

--- a/proc_installing-knative-OCP-311.adoc
+++ b/proc_installing-knative-OCP-311.adoc
@@ -2,10 +2,11 @@
 //
 // assembly_knative-OCP-311.adoc
 
+
 [id='installing-knative-OCP-using-script-311_{context}']
 = Installing Knative on an OpenShift cluster 3.11 using the script provided
 
-Use a script to install Knative on a Minishift cluster.
+Use a script to install Knative 
 
 IMPORTANT: The functionality introduced by Knative on an OpenShift cluster is developer preview only. Red Hat support is not provided, and this release should not be used in a production environment.
 
@@ -41,8 +42,13 @@ NOTE: The installation script takes around 20-30 minutes to complete, depending 
 [start=5]
 . Once the script starts, you will see the following warning and prompt.
 
-   `WARNING: This script will blindly attempt to install OLM, istio, and knative on your OpenShift cluster, so if   any are already there, hijinks may ensue.`
+   `WARNING: This script will blindly attempt to install OLM, istio, and knative on your OpenShift cluster, so if any are already there, hijinks may ensue.`
 
    `If your cluster isn't minishift, ensure $KUBE_SSH_KEY and $KUBE_SSH_USER are set`   
 
    `Pass -q to disable this warning`   
+   
+   `Enter to continue or Ctrl-C to exit:`
+
+
+. Press Enter to continue.

--- a/proc_installing-knative-OCP-4x.adoc
+++ b/proc_installing-knative-OCP-4x.adoc
@@ -36,7 +36,7 @@ NOTE: The installation script takes 20-30 minutes to complete, depending on your
 [start=4]
 . Once the script starts, you will see the following warning and prompt:
 
-    `This script will attempt to install Istio, Knative, and OLM in your Kubernetes/OpenShift cluster.`
+    `WARNING: This script will attempt to install Istio, Knative, and OLM in your Kubernetes/OpenShift cluster.`
     
     `If targeting OpenShift, a recent version of 'oc' should be available in your PATH. Otherwise, 'kubectl' will be used.`
 
@@ -47,3 +47,4 @@ NOTE: The installation script takes 20-30 minutes to complete, depending on your
     `Enter to continue or Ctrl-C to exit:`
 
 . Press Enter to continue.
+

--- a/proc_installing-knative-OCP-4x.adoc
+++ b/proc_installing-knative-OCP-4x.adoc
@@ -24,7 +24,7 @@ NOTE: This Knative on OpenShift preview is only available by using the OpenShift
    `git clone https://github.com/openshift-cloud-functions/knative-operators`   
    `cd knative-operators/`   
    `git fetch --tags`   
-   `git checkout openshift-v0.2.0`   
+   `git checkout openshift-v0.3.0`   
 
 . Set the following SSH properties using your OpenShift cluster credentials.
 

--- a/proc_installing-knative-OCP-4x.adoc
+++ b/proc_installing-knative-OCP-4x.adoc
@@ -26,18 +26,13 @@ NOTE: This Knative on OpenShift preview is only available by using the OpenShift
    `git fetch --tags`   
    `git checkout openshift-v0.3.0`   
 
-. Set the following SSH properties using your OpenShift cluster credentials.
-
-   `export KUBE_SSH_USER=<username>`   
-   `export KUBE_SSH_KEY=<path-to-private-ssh-key>`   
-
 . Navigate to the newly cloned repository and run the `install.sh` script.
 
    `./etc/scripts/install.sh`  
 
-NOTE: The installation script takes around 20-30 minutes to complete, depending on your system.
+NOTE: The installation script takes 20-30 minutes to complete, depending on your system.
 
-[start=5]
+[start=4]
 . Once the script starts, you will see the following warning and prompt.
 
    `WARNING: This script will blindly attempt to install OLM, istio, and knative on your OpenShift cluster, so if   any are already there, hijinks may ensue.`

--- a/proc_installing-knative-OCP-4x.adoc
+++ b/proc_installing-knative-OCP-4x.adoc
@@ -8,6 +8,7 @@
 
 NOTE: This Knative on OpenShift preview is only available by using the OpenShift 4.0 developer preview. 
 
+
 .Prerequisites
 * You will require a Red Hat Developers login to try this. 
 * Using 4.0 clusters with Knative requires visiting link:https://try.openshift.com/[try.openshift.com]
@@ -33,14 +34,16 @@ NOTE: This Knative on OpenShift preview is only available by using the OpenShift
 NOTE: The installation script takes 20-30 minutes to complete, depending on your system.
 
 [start=4]
-. Once the script starts, you will see the following warning and prompt.
+. Once the script starts, you will see the following warning and prompt:
 
-   `WARNING: This script will blindly attempt to install OLM, istio, and knative on your OpenShift cluster, so if   any are already there, hijinks may ensue.`
+    `This script will attempt to install Istio, Knative, and OLM in your Kubernetes/OpenShift cluster.`
+    
+    `If targeting OpenShift, a recent version of 'oc' should be available in your PATH. Otherwise, 'kubectl' will be used.`
 
-   `If your cluster isn't minishift, ensure $KUBE_SSH_KEY and $KUBE_SSH_USER are set`   
+    `If using OpenShift 3.11 and your cluster isn't minishift, ensure \$KUBE_SSH_KEY and \$KUBE_SSH_USER are set`
 
-   `Pass -q to disable this warning`   
-
-   `Enter to continue or Ctrl-C to exit:`   
+    `Pass -q to disable this prompt`
+ 
+    `Enter to continue or Ctrl-C to exit:`
 
 . Press Enter to continue.

--- a/proc_installing-knative-minishift.adoc
+++ b/proc_installing-knative-minishift.adoc
@@ -2,6 +2,7 @@
 //
 // assembly_knative-minishift.adoc
 
+
 [id='installing-knative-minishift_{context}']
 = Installing Knative on a Minishift cluster using a script
 


### PR DESCRIPTION
https://github.com/openshift-cloud-functions/Documentation/blob/23ef3a3db5a6c59045a87d8aced0595e1bd58a06/knative-OCP-4x.md has a section about SSH keys. We don't do any SSH when installing on OpenShift 4 and that entire section can be removed.

**Jira ref**: https://jira.coreos.com/browse/SRVKS-27

Included:
* minor edits
* SRVKS-28 edits also included in PR (https://jira.coreos.com/browse/SRVKS-28)
