### PR TITLE
SRVCOM-426: Update Installation Doc for 0.4.0 release with installer details 

### DIFF
--- a/common/con_knative-OCP-4x.adoc
+++ b/common/con_knative-OCP-4x.adoc
@@ -22,4 +22,4 @@ IMPORTANT: Installation requires the OpenShift version `0.14.0` installer or lat
 | OpenShift    | 4.0 Developer Preview
 |===
 
-NOTE: Long-running clusters will fail due to a broken Maistra sidecar injection.
+NOTE: Long-running clusters are not supported in this release.

--- a/common/con_knative-OCP-4x.adoc
+++ b/common/con_knative-OCP-4x.adoc
@@ -14,8 +14,12 @@ You will need cluster administrator privileges to install and use Knative on an 
 
 === Supported platform version
 
+IMPORTANT: Installation requires the OpenShift version `0.14.0` installer or later. Using the link:https://github.com/openshift/installer/releases[latest version installer] is recommended.  
+
 [cols="50,50"]
 |===
 |** Platform**     | **Supported versions**   
 | OpenShift    | 4.0 Developer Preview
 |===
+
+NOTE: Long-running clusters will fail due to a broken Maistra sidecar injection.

--- a/knative-OCP-4x.md
+++ b/knative-OCP-4x.md
@@ -11,13 +11,13 @@
 
 > **NOTE:** This Knative on OpenShift preview is only available by using the OpenShift 4.0 developer preview. You will require a Red Hat Developers login to try this. Visit [try.openshift.com](https://try.openshift.com/) for getting started information.
 
-> **IMPORTANT:** Installation requires the OpenShift version `0.14.0` installer or later. Using the [lastest version installer](https://github.com/openshift/installer/releases) is recommended.  
+> **IMPORTANT:** Installation requires the OpenShift version `0.14.0` installer or later. Using the [latest version installer](https://github.com/openshift/installer/releases) is recommended.  
 
 | Platform        | Supported versions           |
 | ------------- |:-------------:|
 | OpenShift      | [4.0 Developer Preview](https://try.openshift.com/)		|
 
-> **NOTE:**  Long-running clusters will fail due to a broken Maistra sidecar injection.
+> **NOTE:**  Long-running clusters are not supported in this release.
 
 ## Installing Knative on an OpenShift cluster using the script provided
 

--- a/knative-OCP-4x.md
+++ b/knative-OCP-4x.md
@@ -11,9 +11,13 @@
 
 > **NOTE:** This Knative on OpenShift preview is only available by using the OpenShift 4.0 developer preview. You will require a Red Hat Developers login to try this. Visit [try.openshift.com](https://try.openshift.com/) for getting started information.
 
+> **IMPORTANT:** Installation requires the OpenShift version `0.14.0` installer or later. Using the [lastest version installer](https://github.com/openshift/installer/releases) is recommended.  
+
 | Platform        | Supported versions           |
 | ------------- |:-------------:|
 | OpenShift      | [4.0 Developer Preview](https://try.openshift.com/)		|
+
+> **NOTE:**  Long-running clusters will fail due to a broken Maistra sidecar injection.
 
 ## Installing Knative on an OpenShift cluster using the script provided
 


### PR DESCRIPTION
*Relates to:*
[JIRA SRVCOM-426](https://jira.coreos.com/browse/SRVCOM-426)

-----------------------------------------------------------------------------------------------------------------------
Documentation updated to include:
(1) To have a successful installation, the OpenShift version `0.14.0` installer has to be used
(2) Long-running clusters will fail due to [JIRA SRVCOM-3](https://jira.coreos.com/browse/SRVCOM-3) which is caused by [JIRA MAISTRA-205](https://issues.jboss.org/browse/MAISTRA-205).


