### PR TITLE
Fix wrong indentation for wilcardPolicy 

### DIFF
--- a/knative-OCP-311.md
+++ b/knative-OCP-311.md
@@ -86,7 +86,7 @@ Your Knative services will not be accessible from outside of the OpenShift clust
         kind: Service
         name: knative-ingressgateway
         weight: 100
-        wildcardPolicy: Subdomain   
+      wildcardPolicy: Subdomain   
 
   Apply the yaml file.
 


### PR DESCRIPTION
`wilcardPolicy` was not on the right level of indentation in the example, thus any Wildcard Route creation would be `None`